### PR TITLE
Don't print trailing comma on dump - fixes #7

### DIFF
--- a/macmodelshelf.py
+++ b/macmodelshelf.py
@@ -50,8 +50,7 @@ def model(code):
 
 def _dump():
     print "macmodelshelfdump = {"
-    for code, model in sorted(macmodelshelf.items()):
-        print '    "%s": "%s",' % (code, model)
+    print ",\n".join(['    "%s": "%s"' % (code, model) for code, model in sorted(macmodelshelf.items())])
     print "}"
     
 


### PR DESCRIPTION
sends the dump output as a json ojbect
