### PR TITLE
Return None from model() if code == None

### DIFF
--- a/macmodelshelf.py
+++ b/macmodelshelf.py
@@ -58,6 +58,8 @@ def cleanup_model(model):
 
 def model(code, cleanup=True):
     global macmodelshelf
+    if code == None:
+        return None
     code = code.upper()
     try:
         model = macmodelshelf[code]


### PR DESCRIPTION
If the provided serial doesn't get a match in model_code(), it will
return None, which is in turn sent to model() and tracebacks when that
attempts to upper().

Returning None in model() if the code sent to it is None will lead to
the "Unknown model" message.

Fixes https://github.com/watchmanmonitoring/MacModelShelf/issues/1